### PR TITLE
Watch the ConfigDB over MQTT

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -33,8 +33,16 @@ export const Pg = pg_cjs.native ?? pg_cjs;
 import sparkplug_payload from "sparkplug-payload";
 export const SpB = sparkplug_payload.get("spBv1.0");
 
-import _got_fetch from "got-fetch";
+/* We have to go round the houses a bit here... */
+import got from "got";
+import { createFetch } from "got-fetch";
+
+const configured_got = got.extend({
+    cacheOptions: { shared: true },
+});
+const got_fetch = createFetch(configured_got);
+
 /* Bug fix */
 export function fetch (url, opts) {
-    return _got_fetch(`${url}`, opts);
+    return got_fetch(`${url}`, opts);
 }

--- a/lib/service/configdb-watcher.js
+++ b/lib/service/configdb-watcher.js
@@ -1,0 +1,31 @@
+/*
+ * Factory+ NodeJS Utilities
+ * ConfigDB service interface.
+ * Copyright 2022 AMRC.
+ *
+ * This class is loaded dynamically by service/configdb.js to avoid a
+ * required dependency on rxjs.
+ */
+
+import rx from "rxjs";
+
+export class ConfigDBWatcher {
+    constructor (configdb, device) {
+        this.configdb = configdb;
+        this.device = device;
+    }
+
+    /* For now this returns an Observable<undefined>. It would be much
+     * more useful to return an Observable<UUID> identifying which
+     * object has had its config entry changed but the ConfigDB MQTT
+     * interface doesn't currently expose that information. */
+    application (uuid) {
+        this._app ??= this.device
+            .metric("Last_Changed/Application")
+            .pipe(rx.share());
+
+        return this._app.pipe(
+            rx.filter(u => u == uuid),
+            rx.map(u => undefined));
+    }
+}

--- a/lib/service/configdb-watcher.js
+++ b/lib/service/configdb-watcher.js
@@ -28,4 +28,18 @@ export class ConfigDBWatcher {
             rx.filter(u => u == uuid),
             rx.map(u => undefined));
     }
+
+    watch_config (app, obj) {
+        return this.application(app).pipe(
+            rx.startWith(undefined),
+            rx.switchMap(() => this.configdb.get_config(app, obj)),
+        );
+    }
+
+    watch_search (app, query) {
+        return this.application(app).pipe(
+            rx.startWith(undefined),
+            rx.switchMap(() => this.configdb.search({ app, query })),
+        );
+    }
 }

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -124,10 +124,8 @@ export default class ConfigDB extends ServiceInterface {
             url:        `/v1/app/${opts.app}${klass}/search`,
             query:      qs,
         });
-        if (!res.ok) {
-            this.debug.log("configdb", `Search failed: ${res.status}`);
-            return;
-        }
+        if (!res.ok)
+            this.throw("search failed", res.status);
         return await res.json();
     }
 

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -30,6 +30,17 @@ export default class ConfigDB extends ServiceInterface {
         return json;
     }
 
+    async get_config_etag (app, obj) {
+        const [st, , etag] = await this.fetch({
+            method:     "HEAD",
+            url:        `v1/app/${app}/object/${obj}`,
+        });
+        if (st == 404) return;
+        if (st != 200)
+            this.throw(`Can't get ${app} for ${obj}`, st);
+        return etag;
+    }
+
     async put_config (app, obj, json) {
         const [st] = await this.fetch({
             method:     "PUT",

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -58,6 +58,14 @@ export default class ConfigDB extends ServiceInterface {
         this.throw(`Can't patch ${app} for ${obj}`, st);
     }
 
+    async list_configs (app) {
+        const [st, json] = await this.fetch(`v1/app/${app}/object`);
+        if (st == 404) return;
+        if (st != 200)
+            this.throw(`Can't list objects for ${app}`, st);
+        return json;
+    }
+
     /** Create a new object.
      *
      * @param klass The class of the new object. Required.

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -148,15 +148,18 @@ export default class ConfigDB extends ServiceInterface {
 
     /* Returns a Promise to a watcher object. */
     async watcher () {
-        const fplus = this.fplus;
+        if (!this._watcher) {
+            const fplus = this.fplus;
 
-        const [watcher, spapp, info] = await Promise.all([
-            import("./configdb-watcher.js"),
-            fplus.MQTT.sparkplug_app(),
-            fplus.Directory.get_service_info(this.service),
-        ]);
+            const [watcher, spapp, info] = await Promise.all([
+                import("./configdb-watcher.js"),
+                fplus.MQTT.sparkplug_app(),
+                fplus.Directory.get_service_info(this.service),
+            ]);
 
-        const dev = await spapp.device({ device: info.device });
-        return new watcher.ConfigDBWatcher(this, dev);
+            const dev = await spapp.device({ device: info.device });
+            this._watcher = new watcher.ConfigDBWatcher(this, dev);
+        }
+        return this._watcher;
     }
 }

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -17,11 +17,16 @@ export default class ConfigDB extends ServiceInterface {
         this.log = this.debug.log.bind(this.debug, "configdb");
     }
     
-    async get_config (app, obj) {
-        const [st, json] = await this.fetch(`/v1/app/${app}/object/${obj}`);
-        if (st == 404) return;
+    async get_config_with_etag (app, obj) {
+        const [st, json, etag] = await this.fetch(`v1/app/${app}/object/${obj}`);
+        if (st == 404) return [];
         if (st != 200)
             this.throw(`Can't get ${app} for ${obj}`, st);
+        return [json, etag];
+    }
+
+    async get_config (app, obj) {
+        const [json] = await this.get_config_with_etag(app, obj);
         return json;
     }
 

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -132,4 +132,18 @@ export default class ConfigDB extends ServiceInterface {
 
         return uuids[0];
     }
+
+    /* Returns a Promise to a watcher object. */
+    async watcher () {
+        const fplus = this.fplus;
+
+        const [watcher, spapp, info] = await Promise.all([
+            import("./configdb-watcher.js"),
+            fplus.MQTT.sparkplug_app(),
+            fplus.Directory.get_service_info(this.service),
+        ]);
+
+        const dev = await spapp.device({ device: info.device });
+        return new watcher.ConfigDBWatcher(this, dev);
+    }
 }

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -120,7 +120,7 @@ async function basic_mqtt(url, opts) {
 }
 
 export default class MQTTInterface extends ServiceInterface {
-    async mqtt_client(opts) {
+    async _mqtt_client(opts) {
         opts ??= {};
 
         this.debug.log("mqtt", "Looking up MQTT broker URL");
@@ -144,10 +144,27 @@ export default class MQTTInterface extends ServiceInterface {
             : await gss_mqtt(url, mqopts);
     }
 
+    async mqtt_client (opts) {
+        if (this.client && opts && Object.keys(opts).length)
+            this.throw("MQTT options must be provided on the first connection");
+
+        this.client ??= await this._mqtt_client(opts);
+        return this.client;
+    }
+
     basic_sparkplug_node (opts) {
         return new BasicSparkplugNode({
             ...opts,
             mqttFactory:    will => this.mqtt_client({ ...opts, will }),
         });
+    }
+
+    async sparkplug_app () {
+        if (!this._sparkplug_app) {
+            const spa = await import("@amrc-factoryplus/sparkplug-app");
+            const app = new spa.SparkplugApp({ fplus: this.fplus });
+            this._sparkplug_app = await app.init();
+        }
+        return this._sparkplug_app;
     }
 }

--- a/lib/service/service-interface.js
+++ b/lib/service/service-interface.js
@@ -56,8 +56,10 @@ export class ServiceInterface {
             body,
         };
         const res = await this.fplus.fetch(opts);
-        const json = Optional
-            .ofNullable(res.headers.get("Content-Type"))
+        /* ?? here because Optional.or doesn't work properly */
+        const json = Optional.of(opts.method ?? "GET")
+            .filter(m => m != "HEAD")
+            .map(_ => res.headers.get("Content-Type"))
             .map(content_type.parse)
             .filter(ct => ct.type == "application/json")
             .map(_ => res.json())

--- a/lib/service/service-interface.js
+++ b/lib/service/service-interface.js
@@ -63,7 +63,7 @@ export class ServiceInterface {
             .map(_ => res.json())
             .orElse(undefined);
 
-        return [res.status, await json];
+        return [res.status, await json, res.headers.get("ETag")];
     }
 
     async ping () {

--- a/lib/service/service-interface.js
+++ b/lib/service/service-interface.js
@@ -63,7 +63,15 @@ export class ServiceInterface {
             .map(_ => res.json())
             .orElse(undefined);
 
-        return [res.status, await json, res.headers.get("ETag")];
+        /* We are only interested in strong etags in the form of a UUID */
+        const etag = Optional
+            .ofNullable(res.headers.get("ETag"))
+            .map(et => 
+                /^"([0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12})"$/.exec(et))
+            .map(m => m[1])
+            .orElse(undefined);
+
+        return [res.status, await json, etag];
     }
 
     async ping () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/utilities",
-  "version": "1.0.10-bmz8",
+  "version": "1.1.0",
   "description": "A collection of NodeJS utilities for developing components for Factory+",
   "author": "AMRC",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/utilities",
-  "version": "1.0.9",
+  "version": "1.0.10-bmz8",
   "description": "A collection of NodeJS utilities for developing components for Factory+",
   "author": "AMRC",
   "license": "MIT",

--- a/types/service/configdb.d.ts
+++ b/types/service/configdb.d.ts
@@ -20,6 +20,8 @@ export default class ConfigDB extends ServiceInterface {
     get_config (app: string, obj: string): Promise<any>;
     get_config_with_etag (app: string, obj: string)
         : Promise<[any, string | undefined]>;
+    get_config_etag (app: string, obj: string)
+        : Promise<string | undefined>;
     
     put_config (app: string, obj: string, json: any): Promise<void>;
     delete_config (app: string, obj: string): Promise<void>;

--- a/types/service/configdb.d.ts
+++ b/types/service/configdb.d.ts
@@ -1,12 +1,46 @@
 import {ServiceClient, ServiceInterface} from "../service-client";
 
+interface ConfigDBSearch {
+    app: string;
+    query: object;
+}
+
+interface ConfigDBMappedSearch {
+    app: string;
+    query: object;
+    results: object;
+}
+
 /**
  * ConfigDB service interface.
  */
-export default class Auth extends ServiceInterface {
+export default class ConfigDB extends ServiceInterface {
     constructor(fplus: ServiceClient);
 
     get_config (app: string, obj: string): Promise<any>;
+    get_config_with_etag (app: string, obj: string)
+        : Promise<[any, string | undefined]>;
+    
+    put_config (app: string, obj: string, json: any): Promise<void>;
+    delete_config (app: string, obj: string): Promise<void>;
+    patch_config (app: string, obj: string, type: string, patch: any)
+        : Promise<void>;
+    list_configs (app: string): Promise<string[] | undefined>;
+
+    create_object (klass: string, obj?: string, excl?: boolean)
+        : Promise<string>;
+    delete_object (obj: string): Promise<void>;
+
+    search (opts: ConfigDBSearch): Promise<string[]>;
+    search (opts: ConfigDBMappedSearch): Promise<object>;
+    search (app: string, query: object): Promise<string[]>;
     search (app: string, query: object, results: object): Promise<object>;
-    search (app: string, query: object): Promise<Array<string>>;
+
+    resolve (opts: ConfigDBSearch): Promise<string | undefined>;
+
+    /* This is not exposed to TS at the moment. I don't want to give
+     * this library a required dep on rxjs; the code loads
+     * ConfigDBWatcher dynamically to avoid this. But I don't know if I
+     * can declare the types without such a dependency. */
+    //watcher (): Promise<ConfigDBWatcher>;
 }


### PR DESCRIPTION
Create a class which knows how to watch the ConfigDB change-notify channel over MQTT.

* Currently we can only watch for Application changes. The other channels from the ConfigDB are not working. I think probably the change-notify interface needs rethinking altogether.
* This uses Rx to allow a clean interface to a stream of notifications. The configdb watcher class is loaded dynamically to avoid a fixed dependency on rxjs, which is quite heavy.
* This also pulls in the new `@amrc-factoryplus/sparkplug-app`, which is an Rx-based library for writing consuming applications.

Add additional methods to support returning the etags from the ConfigDB. These associate a UUID with each revision of a config entry.