### PR TITLE
Fix MQTT resubscription on reconnect

### DIFF
--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -68,7 +68,7 @@ export async function gss_mqtt (url, opts) {
         },
     });
     mqtt.on("connect", ack => {
-        //verb("Got CONNACK: %o", ack);
+        verb("Got CONNACK: %o", ack);
         const srv_buf = ack.properties.authenticationData;
         GSS.initSecContext(ctx, srv_buf).then(next => {
             if (next.length)
@@ -77,7 +77,7 @@ export async function gss_mqtt (url, opts) {
              * fails. We may need to be more drastic. */
             if (!ctx.isComplete())
                 throw "MQTT server failed to authenticate itself!";
-            verb("MQTT connected");
+            verb("MQTT connected (on connect)");
             mqtt.emit("gssconnect", ack);
             mqtt.emit("authenticated", ack);
         });
@@ -86,7 +86,10 @@ export async function gss_mqtt (url, opts) {
         verb("MQTT connection closed");
         if (ending) return;
         timers.setTimeout(reconnect)
-            .then(() => gss_init(host))
+            .then(() => {
+                verb("Fetching new GSS creds");
+                return gss_init(host);
+            })
             .then(newgss => {
                 [ctx, buf] = newgss;
                 mqtt.options.properties.authenticationData = buf;

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -66,9 +66,14 @@ export async function gss_mqtt (url, opts) {
             authenticationData: buf,
         },
     });
+    mqtt.on("packetreceive", pkt => {
+        if (pkt.cmd != "connack")
+            return;
+        verb("MQTT clearing GSS creds");
+        mqtt.options.properties.authenticationData = "";
+    });
     mqtt.on("connect", ack => {
         //verb("Got CONNACK: %o", ack);
-        mqtt.options.properties.authenticationData = "";
         const srv_buf = ack.properties.authenticationData;
         GSS.initSecContext(ctx, srv_buf).then(next => {
             if (next.length)

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -47,7 +47,6 @@ function get_verb_from (opts) {
 export async function gss_mqtt (url, opts) {
     opts ??= {};
     const host = new URL(url).hostname;
-    const reconnect = opts.reconnectPeriod ?? 3000;
     const verb = get_verb_from(opts);
 
     /* Has the connection deliberately been closed? */
@@ -58,9 +57,9 @@ export async function gss_mqtt (url, opts) {
     let [ctx, buf] = await gss_init(host);
 
     const mqtt = MQTT.connect(url, {
+        reconnectPeriod: 3000,
         ...opts,
         protocolVersion: 5,
-        reconnectPeriod: 3000,
         properties: {
             ...opts.properties,
             authenticationMethod: "GSSAPI",
@@ -68,7 +67,7 @@ export async function gss_mqtt (url, opts) {
         },
     });
     mqtt.on("connect", ack => {
-        verb("Got CONNACK: %o", ack);
+        //verb("Got CONNACK: %o", ack);
         mqtt.options.properties.authenticationData = "";
         const srv_buf = ack.properties.authenticationData;
         GSS.initSecContext(ctx, srv_buf).then(next => {
@@ -78,7 +77,7 @@ export async function gss_mqtt (url, opts) {
              * fails. We may need to be more drastic. */
             if (!ctx.isComplete())
                 throw "MQTT server failed to authenticate itself!";
-            verb("MQTT connected (on connect)");
+            verb("MQTT connected");
             mqtt.emit("gssconnect", ack);
             mqtt.emit("authenticated", ack);
         });

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -51,7 +51,7 @@ export async function gss_mqtt (url, opts) {
     const verb = get_verb_from(opts);
 
     /* Has the connection deliberately been closed? */
-    //let ending = false;
+    let ending = false;
 
     /* These are renewed every time we reconnect as Kerberos won't let
      * us replay AP-REQ packets. */
@@ -60,7 +60,7 @@ export async function gss_mqtt (url, opts) {
     const mqtt = MQTT.connect(url, {
         ...opts,
         protocolVersion: 5,
-        //reconnectPeriod: 0,
+        reconnectPeriod: 3000,
         properties: {
             ...opts.properties,
             authenticationMethod: "GSSAPI",
@@ -83,8 +83,8 @@ export async function gss_mqtt (url, opts) {
             mqtt.emit("authenticated", ack);
         });
     });
-    mqtt.on("reconnect", () => {
-        //if (ending) return;
+    mqtt.on("close", () => {
+        if (ending) return;
 
         /* We clear the authData when we get a CONNACK (successful or
          * not). We don't need to do anything if our AP-REQ hasn't been
@@ -98,9 +98,9 @@ export async function gss_mqtt (url, opts) {
          * fail (GSS replay) and we will try again.
          *
          * Previously this code bypassed the auto-reconnect logic and
-         * used the "close" event to fetch a new AP-REQ and then
-         * explicitly reconnect. But that also disables the
-         * auto-resubscribe logic, which is not helpful.
+         * explicitly reconnected after fetching the AP-REQ. But this
+         * also disabled the auto-resubscribe logic, which is not
+         * helpful.
          */
         verb("MQTT fetching new GSS creds");
         gss_init(host)
@@ -110,10 +110,10 @@ export async function gss_mqtt (url, opts) {
                 mqtt.options.properties.authenticationData = buf;
             });
     });
-//    mqtt.on("end", () => {
-//        verb("MQTT end");
-//        ending = true;
-//    });
+    mqtt.on("end", () => {
+        verb("MQTT end");
+        ending = true;
+    });
 
     return mqtt;
 }

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -69,6 +69,7 @@ export async function gss_mqtt (url, opts) {
     });
     mqtt.on("connect", ack => {
         verb("Got CONNACK: %o", ack);
+        mqtt.options.properties.authenticationData = "";
         const srv_buf = ack.properties.authenticationData;
         GSS.initSecContext(ctx, srv_buf).then(next => {
             if (next.length)
@@ -84,6 +85,12 @@ export async function gss_mqtt (url, opts) {
     });
     mqtt.on("reconnect", () => {
         //if (ending) return;
+
+        /* We clear the authData when we get a CONNACK (successful or
+         * not). We don't need to do anything if our AP-REQ hasn't been
+         * used yet. */
+        if (mqtt.options.properties.authenticationData != "")
+            return;
 
         /* XXX This will not necessarily complete before the client
          * sends the CONNECT packet. There is nothing we can do about

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -51,7 +51,7 @@ export async function gss_mqtt (url, opts) {
     const verb = get_verb_from(opts);
 
     /* Has the connection deliberately been closed? */
-    let ending = false;
+    //let ending = false;
 
     /* These are renewed every time we reconnect as Kerberos won't let
      * us replay AP-REQ packets. */
@@ -60,7 +60,7 @@ export async function gss_mqtt (url, opts) {
     const mqtt = MQTT.connect(url, {
         ...opts,
         protocolVersion: 5,
-        reconnectPeriod: 0,
+        //reconnectPeriod: 0,
         properties: {
             ...opts.properties,
             authenticationMethod: "GSSAPI",
@@ -82,25 +82,31 @@ export async function gss_mqtt (url, opts) {
             mqtt.emit("authenticated", ack);
         });
     });
-    mqtt.on("close", () => {
-        verb("MQTT connection closed");
-        if (ending) return;
-        timers.setTimeout(reconnect)
-            .then(() => {
-                verb("Fetching new GSS creds");
-                return gss_init(host);
-            })
+    mqtt.on("reconnect", () => {
+        //if (ending) return;
+
+        /* XXX This will not necessarily complete before the client
+         * sends the CONNECT packet. There is nothing we can do about
+         * this with the existing MQTT.js API. The connect attempt will
+         * fail (GSS replay) and we will try again.
+         *
+         * Previously this code bypassed the auto-reconnect logic and
+         * used the "close" event to fetch a new AP-REQ and then
+         * explicitly reconnect. But that also disables the
+         * auto-resubscribe logic, which is not helpful.
+         */
+        verb("MQTT fetching new GSS creds");
+        gss_init(host)
             .then(newgss => {
+                verb("MQTT setting new GSS creds");
                 [ctx, buf] = newgss;
                 mqtt.options.properties.authenticationData = buf;
-                verb("MQTT reconnecting...");
-                mqtt.reconnect();
             });
     });
-    mqtt.on("end", () => {
-        verb("MQTT end");
-        ending = true;
-    });
+//    mqtt.on("end", () => {
+//        verb("MQTT end");
+//        ending = true;
+//    });
 
     return mqtt;
 }


### PR DESCRIPTION
MQTT.js contains logic to automatically reconnect to the broker if the connection is lost, and to automatically resubscribe any subscriptions if this new connection doesn't resume the previous session. Consuming clients rely on this behaviour.

Unfortunately, the code in the GSS client implementation, which bypassed the automatic reconnection in favour of manual reconnection in order to fetch a new Kerberos authentication packet, was causing the auto-re-subscription to be bypassed.

Instead, fetch a new authenticator on "close", but allow the auto-reconnect to still function. There is a race here; it is possible we will attempt to reconnect before we have fresh credentials. This cannot be avoided with the current MQTT.js API. In this case the connect attempt will fail and we will retry; a second authenticator fetch immediately after the first should succeed immediately, as we have a service ticket so it's just crypto and no network traffic.