### PR TITLE
Allow caching CORS preflights

### DIFF
--- a/lib/webapi.js
+++ b/lib/webapi.js
@@ -185,7 +185,7 @@ export class WebAPI {
         let app = this.app;
 
         /* CORS */
-        app.use(cors({ credentials: true }));
+        app.use(cors({ credentials: true, maxAge: 86400 }));
 
         /* Body decoders. These will only decode request bodies of the
          * appropriate content-type. */


### PR DESCRIPTION
Without this a browser will hit the network much more than it needs to. Firefox seems to be worse than Chrome, interestingly; I think it's being a bit more careful about CORS.